### PR TITLE
Python is required for Qt Qml

### DIFF
--- a/CMake/External_Qt.cmake
+++ b/CMake/External_Qt.cmake
@@ -10,6 +10,19 @@ if (Qt_version VERSION_LESS 5.0.0)
   endif()
 endif()
 
+# We need python for Qt 5's Qt_Qml
+if (NOT Qt_version VERSION_LESS 5.0.0)
+  message("Building Qt 5")
+  if (fletch_BUILD_WITH_PYTHON)
+    list(APPEND Qt_ADDITIONAL_PATH ${PYTHON_EXECUTABLE})
+  else()
+    message(FATAL " Python is required for building Qt 5")
+  endif()
+else()
+  message("Building Qt 4")
+endif()
+
+
 if(CMAKE_BUILD_TYPE)
   string(TOLOWER "${CMAKE_BUILD_TYPE}" QT_BUILD_TYPE)
   if(QT_BUILD_TYPE STREQUAL "debug")
@@ -93,7 +106,7 @@ if(WIN32)
 
   if(Qt_WITH_ZLib)
     # Jom needs the path to zlib.dll to build correctly with zlib
-    set(JOM_ADDITIONAL_PATH ${fletch_BUILD_INSTALL_PREFIX}/bin)
+    list(APPEND Qt_ADDITIONAL_PATH ${fletch_BUILD_INSTALL_PREFIX}/bin)
   endif()
 
   set(Qt_build ${fletch_BUILD_PREFIX}/src/Qt-build/BuildQt.bat)
@@ -250,4 +263,3 @@ set(QT_QMAKE_EXECUTABLE \${fletch_ROOT}/bin/qmake)
 
 set(fletch_ENABLED_Qt TRUE)
 ")
-

--- a/Patches/Qt/BuildQt.bat.in
+++ b/Patches/Qt/BuildQt.bat.in
@@ -1,5 +1,5 @@
 REM File configured from BuildQt.bat.in.
 REM Set the path for jom and run it
 cd @fletch_BUILD_PREFIX@/src/Qt
-PATH = @JOM_ADDITIONAL_PATH@;%PATH%
+PATH = @Qt_ADDITIONAL_PATH@;%PATH%
 @JOM_EXE@


### PR DESCRIPTION
For now, we draw a hard line that Python is required for Qt5 since QT_Qml won't build without it. Later patches will evaluate the Qt components we actually support.